### PR TITLE
Add spot price var

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ Only tested on OSX.
 1. Clone this repo.
 2. [Install Terraform.](https://www.terraform.io/intro/getting-started/install.html)
 3. Ensure you have [aws](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) and [jq](https://stedolan.github.io/jq/download/) installed.
-6. Run `./bin/parsecadm plan <aws region> <parsec authcode>` from the root of the repo to see the plan of resources that will be provisioned.
-7. Run `./bin/parsecadm apply <aws region> <parsec authcode>` from the room of the repo to build your Parsec server.
-8. Run `./bin/parsecadm destroy` to remove all resources`.
+4. Create a `terraform.tfvars` in your current directory, and set it up using the template listed below.
+5. Run `./bin/parsecadm plan <aws region> <parsec authcode>` from the root of the repo to see the plan of resources that will be provisioned.
+6. Run `./bin/parsecadm apply <aws region> <parsec authcode>` from the room of the repo to build your Parsec server.
+7. Run `./bin/parsecadm destroy` to remove all resources.
+
+
+## terraform.tfvars
+
+By default, [terraform will use variables stored in the current directory's terraform.tfvars file](https://www.terraform.io/intro/getting-started/variables.html). You can set these up to match your needs.
+
+```
+parsec_authcode = "YOUR_PARSEC_AUTHCODE"
+aws_access_key = "YOUR_AWS_ACCESS_KEY_ID"
+aws_secret = "YOUR_AWS_SECRET_ACCESS_KEY"
+aws_region = "YOUR_AWS_REGION"
+aws_vpc = "YOUR_AWS_VPC"
+aws_subnet = "YOUR_AWS_SUBNET"
+aws_spot_price = "0.7" # This is the price per compute hour you are willing to pay.
+```

--- a/parsec.tf
+++ b/parsec.tf
@@ -18,6 +18,7 @@ variable "aws_subnet" {
 
 variable "aws_spot_price" {
   type = "string"
+  default = "0.7"
 }
 
 # Template
@@ -91,7 +92,7 @@ data "template_file" "user_data" {
 }
 
 resource "aws_spot_instance_request" "parsec" {
-    spot_price = "${coalesce(var.aws_spot_price, "0.7")}"
+    spot_price = "${var.aws_spot_price}"
     ami = "${data.aws_ami.parsec.id}"
     subnet_id = "${var.aws_subnet}"
     instance_type = "g2.2xlarge"

--- a/parsec.tf
+++ b/parsec.tf
@@ -16,6 +16,10 @@ variable "aws_subnet" {
   type = "string"
 }
 
+variable "aws_spot_price" {
+  type = "string"
+}
+
 # Template
 
 provider "aws" {
@@ -87,7 +91,7 @@ data "template_file" "user_data" {
 }
 
 resource "aws_spot_instance_request" "parsec" {
-    spot_price = "0.7"
+    spot_price = "${coalesce(var.aws_spot_price, "0.7")}"
     ami = "${data.aws_ami.parsec.id}"
     subnet_id = "${var.aws_subnet}"
     instance_type = "g2.2xlarge"


### PR DESCRIPTION
Purpose of this PR is to allow configuration of the AWS Spot Instance Price, instead of the default $0.70/hr. Makes it just slightly easier to modify at the .tf_vars level, vs inside the parsec.tf file. If it `aws_spot_price` is not configured inside of the .tf_vars, we use the default of 0.7
